### PR TITLE
Fix NumPy compatibility issue with PyTorch 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,12 @@ RUN grep -q "spacing_width.*0" handler.py && \
     grep -q "spacing_color.*white" handler.py && \
     echo "✅ ImageStitch parameters verified in handler.py"
 
-# Install Python dependencies without NumPy conflicts
+# Install Python dependencies with proper NumPy version for PyTorch 2.1.0 compatibility
 RUN pip install --upgrade pip && \
+    pip uninstall -y numpy && \
     pip install opencv-python-headless && \
-    pip install -r requirements.txt
+    pip install -r requirements.txt && \
+    pip install "numpy<2.0.0"
 
 # Simple verification that basic imports work
 RUN python -c "print('✅ Build verification complete')"
@@ -46,6 +48,11 @@ RUN echo '#!/usr/bin/env python' > /app/verify_startup.py && \
     echo '    import numpy as np' >> /app/verify_startup.py && \
     echo '    import torch' >> /app/verify_startup.py && \
     echo '    print(f"[STARTUP] ✅ NumPy {np.__version__} ready")' >> /app/verify_startup.py && \
+    echo '    print(f"[STARTUP] ✅ PyTorch {torch.__version__} ready")' >> /app/verify_startup.py && \
+    echo '    # Test NumPy-PyTorch compatibility' >> /app/verify_startup.py && \
+    echo '    test_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)' >> /app/verify_startup.py && \
+    echo '    test_tensor = torch.from_numpy(test_array)' >> /app/verify_startup.py && \
+    echo '    print("[STARTUP] ✅ NumPy-PyTorch compatibility verified")' >> /app/verify_startup.py && \
     echo '    print("[STARTUP] ✅ All dependencies verified")' >> /app/verify_startup.py && \
     echo 'except Exception as e:' >> /app/verify_startup.py && \
     echo '    print(f"[STARTUP] ❌ Dependency error: {e}")' >> /app/verify_startup.py && \

--- a/fix_numpy_compatibility.py
+++ b/fix_numpy_compatibility.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+ComfyUI NumPy Compatibility Fix
+
+This script fixes the "RuntimeError: Numpy is not available" error
+that occurs when PyTorch 2.1.0 is used with NumPy 2.x.
+
+Usage: python fix_numpy_compatibility.py
+"""
+
+import subprocess
+import sys
+import importlib.util
+
+def run_command(cmd):
+    """Run a shell command and return the result."""
+    try:
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        return result.returncode == 0, result.stdout, result.stderr
+    except Exception as e:
+        return False, "", str(e)
+
+def check_package_version(package_name):
+    """Check if a package is installed and return its version."""
+    try:
+        spec = importlib.util.find_spec(package_name)
+        if spec is None:
+            return None
+        
+        module = importlib.import_module(package_name)
+        return getattr(module, '__version__', 'unknown')
+    except Exception:
+        return None
+
+def main():
+    print("🔧 ComfyUI NumPy Compatibility Fix")
+    print("=" * 50)
+    
+    # Check current versions
+    numpy_version = check_package_version('numpy')
+    torch_version = check_package_version('torch')
+    
+    print(f"Current NumPy version: {numpy_version}")
+    print(f"Current PyTorch version: {torch_version}")
+    
+    if numpy_version is None:
+        print("❌ NumPy is not installed!")
+        return 1
+    
+    if torch_version is None:
+        print("❌ PyTorch is not installed!")
+        return 1
+    
+    # Check if we have the problematic combination
+    if numpy_version.startswith('2.') and torch_version.startswith('2.1.'):
+        print("\n🚨 ISSUE DETECTED: NumPy 2.x with PyTorch 2.1.x")
+        print("This combination causes 'RuntimeError: Numpy is not available'")
+        print("\n🔧 Fixing by downgrading NumPy to 1.x...")
+        
+        # Uninstall current NumPy
+        print("Uninstalling current NumPy...")
+        success, stdout, stderr = run_command("pip uninstall -y numpy")
+        if not success:
+            print(f"❌ Failed to uninstall NumPy: {stderr}")
+            return 1
+        
+        # Install compatible NumPy version
+        print("Installing NumPy < 2.0.0...")
+        success, stdout, stderr = run_command("pip install 'numpy<2.0.0'")
+        if not success:
+            print(f"❌ Failed to install compatible NumPy: {stderr}")
+            return 1
+        
+        # Verify the fix
+        print("Verifying the fix...")
+        try:
+            import numpy as np
+            import torch
+            
+            # Test compatibility
+            test_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+            test_tensor = torch.from_numpy(test_array)
+            
+            print(f"✅ SUCCESS! NumPy {np.__version__} is now compatible with PyTorch {torch.__version__}")
+            print("✅ torch.from_numpy() test passed")
+            
+        except Exception as e:
+            print(f"❌ Verification failed: {e}")
+            return 1
+    
+    elif numpy_version.startswith('1.'):
+        print("✅ NumPy version is already compatible (1.x)")
+        
+        # Still test compatibility
+        try:
+            import numpy as np
+            import torch
+            test_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+            test_tensor = torch.from_numpy(test_array)
+            print("✅ NumPy-PyTorch compatibility test passed")
+        except Exception as e:
+            print(f"❌ Compatibility test failed: {e}")
+            print("There may be another issue beyond NumPy version compatibility.")
+            return 1
+    
+    else:
+        print("ℹ️  Versions look compatible, but testing...")
+        try:
+            import numpy as np
+            import torch
+            test_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+            test_tensor = torch.from_numpy(test_array)
+            print("✅ NumPy-PyTorch compatibility test passed")
+        except Exception as e:
+            print(f"❌ Compatibility test failed: {e}")
+            print("You may need to check your specific PyTorch and NumPy versions.")
+            return 1
+    
+    print("\n🎉 Fix completed! You can now run ComfyUI without the NumPy error.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-# Note: numpy is installed separately in Dockerfile to avoid version conflicts
+# Note: numpy is pinned to 1.x for compatibility with PyTorch 2.1.0
+numpy<2.0.0
 comfyui-frontend-package==1.23.4
 comfyui-workflow-templates==0.1.35
 comfyui-embedded-docs==0.2.4


### PR DESCRIPTION
- Pin numpy<2.0.0 in requirements.txt for PyTorch 2.1.0 compatibility
- Update Dockerfile to properly handle NumPy installation
- Add startup verification for NumPy-PyTorch compatibility
- Create fix_numpy_compatibility.py script for immediate resolution

Resolves 'RuntimeError: Numpy is not available' error in serverless environments